### PR TITLE
fix 400 error response when importing open sans font

### DIFF
--- a/package/lbh/core/_all.scss
+++ b/package/lbh/core/_all.scss
@@ -1,5 +1,5 @@
 // sass-lint:disable no-url-protocols no-url-domains
-@import url("https://fonts.googleapis.com/css2?family=Open+Sans:300,400,600,700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap");
 // sass-lint:enable no-url-protocols no-url-domains
 
 @import "node_modules/govuk-frontend/govuk/core/all";

--- a/src/lbh/core/_all.scss
+++ b/src/lbh/core/_all.scss
@@ -1,5 +1,5 @@
 // sass-lint:disable no-url-protocols no-url-domains
-@import url("https://fonts.googleapis.com/css2?family=Open+Sans:300,400,600,700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap");
 // sass-lint:enable no-url-protocols no-url-domains
 
 @import "node_modules/govuk-frontend/govuk/core/all";


### PR DESCRIPTION
The Google open sans font was imported with the wrong parameters, causing an error in any project importing LBH-frontend 3.0.0

![image](https://user-images.githubusercontent.com/63246336/88275636-9cdc3900-ccd5-11ea-9ff2-de33daf969f3.png)
