### PR TITLE
chore(docs): added missing checkboxes component from the docs

### DIFF
--- a/sidebars.config.js
+++ b/sidebars.config.js
@@ -25,6 +25,7 @@ module.exports = {
       "components/button",
       "components/contacts-block",
       "components/character-count",
+      "components/checkboxes",
       "components/cookie-banner",
       "components/date-input",
       "components/details",


### PR DESCRIPTION
Checkboxes component was missing from the docs sidebar:

https://design-system.hackney.gov.uk/components/checkboxes/﻿
