### PR TITLE
fix(button): fixed size of secondary button

### DIFF
--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -16,6 +16,23 @@ import InitAll from "../../src/InitAll"
 </button>
 ```
 
+## Button secondary
+
+<button class="govuk-button govuk-secondary lbh-button lbh-button--secondary" data-module="govuk-button">
+  Secondary button
+</button>
+
+### HTML
+
+```html
+<button
+  class="govuk-button govuk-secondary lbh-button lbh-button--secondary"
+  data-module="govuk-button"
+>
+  Secondary button
+</button>
+```
+
 ## Button disabled
 
 <button disabled="disabled" aria-disabled="true" class="govuk-button  lbh-button lbh-button--disabled govuk-button--disabled" data-module="govuk-button">

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -80,8 +80,14 @@ import InitAll from "../../src/InitAll"
 
 ### HTML
 
-```
-<a href="/" role="button" draggable="false" class="govuk-button  lbh-button lbh-button--disabled govuk-button--disabled" data-module="govuk-button">
+```html
+<a
+  href="/"
+  role="button"
+  draggable="false"
+  class="govuk-button  lbh-button lbh-button--disabled govuk-button--disabled"
+  data-module="govuk-button"
+>
   Disabled link button
 </a>
 ```

--- a/lbh/components/lbh-button/_button.scss
+++ b/lbh/components/lbh-button/_button.scss
@@ -43,7 +43,6 @@
       border: 1px solid lbh-colour("lbh-a01");
       color: lbh-colour("lbh-a01");
       background: lbh-colour("lbh-white");
-      box-shadow: inset lbh-colour("lbh-secondary-inner-shadow") 0 -2px 0 0;
 
       &:hover {
         color: lbh-colour("lbh-white");
@@ -57,7 +56,6 @@
         opacity: 1;
         color: lbh-colour("lbh-grey-1");
         background: lbh-colour("lbh-secondary-disabled");
-        box-shadow: inset lbh-colour("lbh-primary-inner-shadow") 0 -2px 0;
       }
     }
 


### PR DESCRIPTION
The height of the secondary button is different from the normal one, removing the `box-shadow inset` is fixing the problem.

Before:
<img width="442" alt="Screenshot 2021-03-19 at 14 55 58" src="https://user-images.githubusercontent.com/435399/111803048-f598bb80-88ce-11eb-9a7a-9a0136ebcee5.png">

After:
<img width="449" alt="Screenshot 2021-03-19 at 15 17 40" src="https://user-images.githubusercontent.com/435399/111803060-f7fb1580-88ce-11eb-93b1-ca072c4865c2.png">
