### PR TITLE
fix(label): govuk label overrides work again

### DIFF
--- a/lbh/components/lbh-label/_label.scss
+++ b/lbh/components/lbh-label/_label.scss
@@ -9,4 +9,25 @@
   .lbh-label {
     @include lbh-label;
   }
+
+  // copied these over from govuk frontend because i couldn't see any other way to win the specificity battle
+  // solves: https://github.com/LBHackney-IT/lbh-frontend/issues/147
+  .govuk-label--xl {
+    @include govuk-font($size: 48, $weight: bold);
+    margin-bottom: govuk-spacing(3);
+  }
+
+  .govuk-label--l {
+    @include govuk-font($size: 36, $weight: bold);
+    margin-bottom: govuk-spacing(3);
+  }
+
+  .govuk-label--m {
+    @include govuk-font($size: 24, $weight: bold);
+    margin-bottom: govuk-spacing(2);
+  }
+
+  .govuk-label--s {
+    @include govuk-font($size: 19, $weight: bold);
+  }
 }


### PR DESCRIPTION
fix this issue: https://github.com/LBHackney-IT/lbh-frontend/issues/147

by copying over some override classes from `govuk-frontend`. not ideal but can't think of a better way.

may be better to have our own override classes?