### PR TITLE
chore(repo): add Webstorm config folder to git ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 
 .cache
+
+# IDE
+.idea/


### PR DESCRIPTION
Add the default Webstorm IDE config folder to the list of files ignored by Git as it is not recommended to share this folder between users.