### PR TITLE
consolidate font weights

### DIFF
--- a/lbh/components/lbh-pagination/_pagination.scss
+++ b/lbh/components/lbh-pagination/_pagination.scss
@@ -41,7 +41,7 @@
       }
 
       &--current {
-        font-weight: 700;
+        font-weight: $lbh-font-weight-bold;
         pointer-events: none;
         cursor: default;
 

--- a/lbh/settings/_typography.scss
+++ b/lbh/settings/_typography.scss
@@ -34,7 +34,7 @@ $lbh-font-weight-regular: 400 !default;
 ///
 /// @type Number
 /// @access public
-$lbh-font-weight-bold: 700 !default;
+$lbh-font-weight-bold: 600 !default;
 
 /// Font weight for medium typography
 ///
@@ -46,4 +46,4 @@ $lbh-font-weight-medium: 600 !default;
 ///
 /// @type Number
 /// @access public
-$lbh-font-weight-light: 300 !default;
+$lbh-font-weight-light: 400 !default;


### PR DESCRIPTION
this makes the default weight across the design system open sans 400 (regular) rather than 300 (light).

it also eliminates variation between semibold and bold weights, using 600 everywhere.