### PR TITLE
Update header.md

### DIFF
--- a/docs/components/header.md
+++ b/docs/components/header.md
@@ -746,5 +746,5 @@ import PreviewArea from "../../src/PreviewArea"
       </div>
     </div>
   </div>
-</header>
+</header> 
 ```


### PR DESCRIPTION
When the 'Header with service name' is used, the WAVE always says there is a contrast issue with the 'Service name' text. Not sure why it is saying this. Maybe the text is a bit thin and it is causing this issue. Can this be looked into. 
It may also affect the 'Header with links'