### PR TITLE
Fix selected tab top margin and text decoration other tabs

### DIFF
--- a/lbh/components/lbh-tabs/_tabs.scss
+++ b/lbh/components/lbh-tabs/_tabs.scss
@@ -8,6 +8,10 @@
       margin-top: 0;
     }
 
+    .govuk-tabs__list-item--selected {
+      margin-top: -5px;
+    }
+
     .govuk-tabs__panel {
       margin-top: 0;
     }

--- a/lbh/components/lbh-tabs/_tabs.scss
+++ b/lbh/components/lbh-tabs/_tabs.scss
@@ -15,5 +15,13 @@
     .govuk-tabs__panel {
       margin-top: 0;
     }
+
+    .govuk-tabs__tab {
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
 }


### PR DESCRIPTION
Currently the tab appearance does not match the appearance in the docs. This is due to the specificity of the rules being the same so we need to add some extra rules to restore the correct appearance.

### Before
![image](https://user-images.githubusercontent.com/6321/135107051-cf4b60f9-4199-4186-8de3-82cbe115b9d1.png)

### After
![image](https://user-images.githubusercontent.com/6321/135107260-19e715c7-13a1-440a-aef6-a68714a00362.png)
