### PR TITLE
fix(contact-block): Update to working Mapbox

### DIFF
--- a/lbh/components/lbh-contact-block/contact-block.js
+++ b/lbh/components/lbh-contact-block/contact-block.js
@@ -54,14 +54,16 @@ Map.prototype.setBounds = function() {
 
 Map.prototype.initMapboxTiles = function() {
   var osmStreet = tileLayer(
-    "https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}",
+    "https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}",
     {
       fadeAnimation: false,
       opacity: 1,
       attribution:
         'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="https://mapbox.com">Mapbox</a>',
+      tileSize: 512,
       maxZoom: this.maxZoom,
-      id: "mapbox.streets",
+      zoomOffset: -1,
+      id: 'mapbox/streets-v11',
       accessToken: this.accessToken
     }
   );

--- a/static/assets/images/contact/map-marker.svg
+++ b/static/assets/images/contact/map-marker.svg
@@ -1,0 +1,5 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0"
+	 width="512px" height="512px" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+	 	<title>Map marker</title>
+		<path fill="#00664f" d="M256,0C167.641,0,96,71.625,96,160c0,24.75,5.625,48.219,15.672,69.125C112.234,230.313,256,512,256,512l142.594-279.375 C409.719,210.844,416,186.156,416,160C416,71.625,344.375,0,256,0z"/>
+</svg>


### PR DESCRIPTION
Mapbox classic styles were deprecated in 2020: https://blog.mapbox.com/deprecating-studio-classic-styles-d8892ac38cb4
This moves to what I believe is the current equivalent. It also adds a copy of the map marker from under lbh to under static so the documentation can refer to it okay. Before and after shots below:

<img src="https://user-images.githubusercontent.com/154364/135441479-d98fc3f9-a5c0-4204-ba01-ceb22f23cec3.png" width="45%" alt="Current documentation, map not working"> <img src="https://user-images.githubusercontent.com/154364/135442265-9aa187f9-d569-4f40-bfbb-c36ee97f4d63.png" width="45%" alt="Local build of documentation with working map">
