### PR TITLE
fix(header): remove enlarged gap for borders

### DIFF
--- a/lbh/components/lbh-header/_header.scss
+++ b/lbh/components/lbh-header/_header.scss
@@ -3,7 +3,7 @@
     position: relative;
     z-index: lbh-depth-index("header");
     margin-top: 0;
-    @include lbh-rem(padding-bottom, 21);
+    @include lbh-rem(padding-bottom, 16);
     border-bottom: 2px solid lbh-colour("lbh-a03");
     background: lbh-colour("lbh-white");
 
@@ -140,6 +140,7 @@
     }
 
     &__logo-text {
+      color: lbh-colour("lbh-white");
       @include govuk-visually-hidden;
     }
 


### PR DESCRIPTION
Removes the large gap between the bottom of the header and it's borders.

![image](https://user-images.githubusercontent.com/3967435/139852744-5f8e4f35-f6b4-46e7-86a4-92e589da5dec.png)

Also closes https://github.com/LBHackney-IT/lbh-frontend/pull/176 by applying a white colour to the fallback text.
