### PR TITLE
fix: Improve small checkbox/radio display.

### DIFF
--- a/docs/components/radios.md
+++ b/docs/components/radios.md
@@ -1408,7 +1408,7 @@ title: Radios
   <legend class="govuk-fieldset__legend">
     How do you want to be contacted?
   </legend>
-  <div class="govuk-radios lbh-radios">
+  <div class="govuk-radios govuk-radios--small lbh-radios">
         <div class="govuk-radios__item">
           <input class="govuk-radios__input" id="how-contacted-2" name="how-contacted-2" type="radio" value="email" />
           <label class="govuk-label govuk-radios__label" for="how-contacted-2">
@@ -1439,7 +1439,7 @@ title: Radios
     <legend class="govuk-fieldset__legend">
       How do you want to be contacted?
     </legend>
-    <div class="govuk-radios lbh-radios">
+    <div class="govuk-radios govuk-radios--small lbh-radios">
       <div class="govuk-radios__item">
         <input
           class="govuk-radios__input"
@@ -1583,7 +1583,7 @@ title: Radios
   <span id="how-contacted-2-error" class="govuk-error-message">
   <span class="govuk-visually-hidden">Error:</span> Select a thing
   </span>
-  <div class="govuk-radios lbh-radios">
+  <div class="govuk-radios govuk-radios--small lbh-radios">
         <div class="govuk-radios__item">
           <input class="govuk-radios__input" id="how-contacted-2" name="how-contacted-2" type="radio" value="email" />
           <label class="govuk-label govuk-radios__label" for="how-contacted-2">
@@ -1617,7 +1617,7 @@ title: Radios
     <span id="how-contacted-2-error" class="govuk-error-message">
       <span class="govuk-visually-hidden">Error:</span> Select a thing
     </span>
-    <div class="govuk-radios lbh-radios">
+    <div class="govuk-radios govuk-radios--small lbh-radios">
       <div class="govuk-radios__item">
         <input
           class="govuk-radios__input"
@@ -1666,7 +1666,7 @@ title: Radios
   <legend class="govuk-fieldset__legend">
     How do you want to be contacted?
   </legend>
-  <div class="govuk-radios lbh-radios">
+  <div class="govuk-radios govuk-radios--small lbh-radios">
         <div class="govuk-radios__item">
           <input class="govuk-radios__input" id="how-contacted-2" name="how-contacted-2" type="radio" value="email" aria-describedby="how-contacted-2-item-hint" />
           <label class="govuk-label govuk-radios__label" for="how-contacted-2">
@@ -1700,7 +1700,7 @@ title: Radios
     <legend class="govuk-fieldset__legend">
       How do you want to be contacted?
     </legend>
-    <div class="govuk-radios lbh-radios">
+    <div class="govuk-radios govuk-radios--small lbh-radios">
       <div class="govuk-radios__item">
         <input
           class="govuk-radios__input"
@@ -1756,7 +1756,7 @@ title: Radios
   <legend class="govuk-fieldset__legend">
     How do you want to be contacted?
   </legend>
-  <div class="govuk-radios lbh-radios">
+  <div class="govuk-radios govuk-radios--small lbh-radios">
         <div class="govuk-radios__item">
           <input class="govuk-radios__input" id="how-contacted-2" name="how-contacted-2" type="radio" value="email" />
           <label class="govuk-label govuk-radios__label" for="how-contacted-2">
@@ -1787,7 +1787,7 @@ title: Radios
     <legend class="govuk-fieldset__legend">
       How do you want to be contacted?
     </legend>
-    <div class="govuk-radios lbh-radios">
+    <div class="govuk-radios govuk-radios--small lbh-radios">
       <div class="govuk-radios__item">
         <input
           class="govuk-radios__input"
@@ -1837,7 +1837,7 @@ title: Radios
   <legend class="govuk-fieldset__legend">
     How do you want to be contacted?
   </legend>
-  <div class="govuk-radios lbh-radios govuk-radios--conditional" data-module="govuk-radios">
+  <div class="govuk-radios govuk-radios--small lbh-radios govuk-radios--conditional" data-module="govuk-radios">
         <div class="govuk-radios__item">
           <input class="govuk-radios__input" id="how-contacted-2" name="how-contacted-2" type="radio" value="email" data-aria-controls="conditional-how-contacted-2" />
           <label class="govuk-label govuk-radios__label" for="how-contacted-2">
@@ -1873,7 +1873,7 @@ title: Radios
       How do you want to be contacted?
     </legend>
     <div
-      class="govuk-radios lbh-radios govuk-radios--conditional"
+      class="govuk-radios govuk-radios--small lbh-radios govuk-radios--conditional"
       data-module="govuk-radios"
     >
       <div class="govuk-radios__item">

--- a/lbh/components/lbh-checkboxes/_checkboxes.scss
+++ b/lbh/components/lbh-checkboxes/_checkboxes.scss
@@ -28,5 +28,17 @@
       @include lbh-body-m;
       margin-bottom: 0;
     }
+
+    &.govuk-checkboxes--small {
+      .govuk-checkboxes__item {
+        margin-bottom: 0;
+      }
+
+      .govuk-checkboxes__label {
+        margin-top: -2px;
+        margin-bottom: 0;
+        line-height: inherit;
+      }
+    }
   }
 }

--- a/lbh/components/lbh-radios/_radios.scss
+++ b/lbh/components/lbh-radios/_radios.scss
@@ -25,5 +25,13 @@
     .govuk-hint {
       @include lbh-hint;
     }
+
+    &.govuk-radios--small {
+      .govuk-label {
+        margin-top: -2px;
+        margin-bottom: 0;
+        line-height: inherit;
+      }
+    }
   }
 }


### PR DESCRIPTION
And fix radio documentation missing small classes. Some before/after:

## Small checkboxes

<img src="https://user-images.githubusercontent.com/154364/141508087-f63ae5ef-8195-4c95-af25-1dcc47790a3b.png" alt="small checkboxes before" align="top"> <img src="https://user-images.githubusercontent.com/154364/141508100-1ddf2892-6c84-4b32-8542-d23bbec6b063.png" alt="small checkboxes after" align="top">

## Small radios

<img src="https://user-images.githubusercontent.com/154364/141508113-3f691ed3-c164-47ea-a347-ffe5a519dde6.png" width="45%" alt="Small radios before" align="top"> <img src="https://user-images.githubusercontent.com/154364/141508123-2d9b33ab-031e-49f1-bde9-45ffffec7a96.png" width="45%" alt="Small radios after" align="top">

## Small radios with divider

<img src="https://user-images.githubusercontent.com/154364/141508141-f0b94c68-5628-451b-a332-69cd61d64772.png" width="45%" alt="Small radios with divider before" align="top"> <img src="https://user-images.githubusercontent.com/154364/141508160-565bc891-6efe-4168-8fe1-ce20142d791f.png" width="45%" alt="Small radios with divider after" align="top">
