### PR TITLE
Replace em dash with en dash in pagination summary

### DIFF
--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -46,7 +46,7 @@ Users generally find proper pagination easier and more predictable to use than a
 
 ```html
 <nav class="lbh-pagination">
-  <div class="lbh-pagination__summary">Showing 101—150 of 246 results</div>
+  <div class="lbh-pagination__summary">Showing 101–150 of 246 results</div>
   <ul class="lbh-pagination">
     <li class="lbh-pagination__item">
       <a class="lbh-pagination__link" href="#" aria-label="Previous page">


### PR DESCRIPTION
Replace em dash used in pagination indicator with an en dash. Recommended to use the latter for a number range.

See https://www.lighthouseproofreading.co.uk/blog/how-to-use-an-en-dash-and-em-dash-correctly