### PR TITLE
pin docusaurus to 1x and override nondesass

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,6 +10,8 @@ jobs:
   checks:
     if: github.event_name != 'push'
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --openssl-legacy-provider
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
@@ -24,6 +26,8 @@ jobs:
   gh-release:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --openssl-legacy-provider
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@types/jest": "^26.0.22",
         "copyfiles": "^2.4.1",
         "cross-var": "^1.1.0",
-        "docusaurus-plugin-sass": "0.2.6",
+        "docusaurus-plugin-sass": "0.1.11",
         "esbuild": "^0.25.0",
         "jest": "^26.6.3",
         "npm-run-all": "^4.1.5",
@@ -10421,17 +10421,17 @@
       }
     },
     "node_modules/docusaurus-plugin-sass": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/docusaurus-plugin-sass/-/docusaurus-plugin-sass-0.2.6.tgz",
-      "integrity": "sha512-2hKQQDkrufMong9upKoG/kSHJhuwd+FA3iAe/qzS/BmWpbIpe7XKmq5wlz4J5CJaOPu4x+iDJbgAxZqcoQf0kg==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-sass/-/docusaurus-plugin-sass-0.1.11.tgz",
+      "integrity": "sha512-Lm3g5o4IQuABLzxLnvRVxffLQQQrua9bPK2niRULJko2/EnHDofxhKP0lDX7h+zSUvb3eVOcG4XkRfb5uPUdnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "sass-loader": "^16.0.2"
+        "node-sass": "^4.13.1",
+        "sass-loader": "^10.0.2"
       },
       "peerDependencies": {
-        "@docusaurus/core": "^2.0.0-beta || ^3.0.0-alpha",
-        "sass": "^1.30.0"
+        "@docusaurus/core": "^2.0.0"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -17048,6 +17048,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/last-call-webpack-plugin": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
@@ -18659,6 +18669,23 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.70.tgz",
       "integrity": "sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==",
       "dev": true
+    },
+    "node_modules/node-sass": {
+      "name": "sass",
+      "version": "1.32.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.8.tgz",
+      "integrity": "sha512-Sl6mIeGpzjIUZqvKnKETfMf0iDAswD9TNlv13A7aAF3XZlRPMq4VvJWBC2N2DXbp94MQVdNSFG6LfF/iOXrPHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": ">=2.0.0 <4.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
     },
     "node_modules/noms": {
       "version": "0.0.0",
@@ -29137,30 +29164,33 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "16.0.8",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.8.tgz",
-      "integrity": "sha512-hcov4ZwZJIGbEuyNr9EmiTmZueyrxSToE6GOzoZnq5JM7ecRO7ttyvilPn+VmRsqiP16+VYZzVnGZj/hzZgKBA==",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.5.2.tgz",
+      "integrity": "sha512-vMUoSNOUKJILHpcNCCyD23X34gve1TS7Rjd9uXHeKqhvBG39x6XbswFDtpbTElj6XdMFezoWhkh5vtKudf2cgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "neo-async": "^2.6.2"
+        "klona": "^2.0.4",
+        "loader-utils": "^2.0.0",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.0.0",
+        "semver": "^7.3.2"
       },
       "engines": {
-        "node": ">= 18.12.0"
+        "node": ">= 10.13.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
+        "fibers": ">= 3.1.0",
         "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
         "sass": "^1.3.0",
-        "sass-embedded": "*",
-        "webpack": "^5.0.0"
+        "webpack": "^4.36.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
-        "@rspack/core": {
+        "fibers": {
           "optional": true
         },
         "node-sass": {
@@ -29168,13 +29198,54 @@
         },
         "sass": {
           "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
         }
+      }
+    },
+    "node_modules/sass-loader/node_modules/loader-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/sass-loader/node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/sass-loader/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/sassdoc": {

--- a/package.json
+++ b/package.json
@@ -9,18 +9,22 @@
   "engines": {
     "node": ">=20"
   },
+  "overrides": {
+    "node-sass": "npm:sass@1.32.8",
+    "sass-loader": "10.5.2"
+  },
   "scripts": {
     "build:sass": "cross-var sass lbh/all.scss dist/lbh-frontend-$npm_package_version.min.css --load-path=./ --no-source-map",
     "build:sass-ie8": "cross-var sass lbh/all-ie8.scss dist/lbh-frontend-ie8-$npm_package_version.min.css --load-path=./ --no-source-map",
     "build:js": "node scripts/build-js.js",
     "build:sassdoc": "sassdoc lbh --dest static/sassdoc",
-    "build:docs": "docusaurus build",
+    "build:docs": "NODE_OPTIONS=--openssl-legacy-provider docusaurus build",
     "build:assets": "copyfiles lbh/assets/**/**/**/* dist/assets -u 2",
     "build": "npm-run-all build:*",
     "clean:docs": "docusaurus clear",
     "clean:dist": "rimraf dist",
     "clean": "npm-run-all clean:*",
-    "start": "docusaurus start",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider docusaurus start",
     "semantic-release": "semantic-release",
     "test": "jest",
     "prepublishOnly": "npm-run-all -s clean build"
@@ -38,7 +42,7 @@
     "@types/jest": "^26.0.22",
     "copyfiles": "^2.4.1",
     "cross-var": "^1.1.0",
-    "docusaurus-plugin-sass": "0.2.6",
+    "docusaurus-plugin-sass": "0.1.11",
     "esbuild": "^0.25.0",
     "jest": "^26.6.3",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
What
--

The documents action was breaking on production preview. 

- Pins docusaurus to older version that won't throw to avoid webpack 5 error `this.getOptions()`
- Set --openssl-legacy-provider to enable legacy provider because modern sslprovider won't work as a default 

These are not long term fixes - they just allow the pipeline to run to prove we can deploy a NPM package before fixes.