### PR TITLE
chore(ci): trigger workflows after semantic-release action upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+# Runs semantic-release on push to main (comment to trigger CI).
 name: Release to NPM
 on:
   push:


### PR DESCRIPTION
Triggers GitHub Actions on main after #212. That merge was skipped because the squash commit body contained skip ci from old semantic-release commits.

Will merge with removed squash body
