### PR TITLE
chore: documents update

### DIFF
--- a/.github/merge-policy.md
+++ b/.github/merge-policy.md
@@ -1,0 +1,60 @@
+# GitHub merge policy (maintainers)
+
+Internal reference for repository admins. Contributors should follow [Git workflow](../docs/contributing/git-workflow.md) instead.
+
+## Branch roles
+
+| Branch | Default? | Purpose |
+|--------|----------|---------|
+| `develop` | Yes | Integration — all feature PRs land here |
+| `main` | No | Release — promotion merges and Release Please |
+
+## Merge method by PR type
+
+| Pull request | Merge button |
+|--------------|--------------|
+| Feature branch → `develop` | **Squash and merge** |
+| `develop` → `main` (promotion) | **Create a merge commit** |
+| Release Please (`release-please--*`) → `main` | **Create a merge commit** |
+| `main` → `develop` (post-release sync) | **Create a merge commit** |
+
+Never squash-merge between `main` and `develop`.
+
+## Release cycle (maintainer checklist)
+
+### 1. Promote `develop` → `main` (optional before release)
+
+- Open PR: `develop` → `main`
+- Merge with **merge commit**
+- Use a conventional title (`feat:`, `fix:`, etc.) — this feeds Release Please
+- **No sync back to `develop` yet** — file content is already on `develop`
+
+### 2. Merge Release Please PR on `main`
+
+- PR branch name starts with `release-please--`
+- Merge with **merge commit**
+- [Release please workflow](workflows/release-please.yml) publishes to npm `latest`
+
+### 3. Merge the automated sync PR on `develop`
+
+After a successful release, the workflow opens:
+
+- **Title:** `chore: sync main after release <tag>`
+- **Branch:** `sync/main-after-<tag>` → `develop`
+
+A maintainer must **approve and merge with a merge commit**. Branch protection prevents the bot from merging on its own. Merge promptly so `develop` does not drift from `main` on version and changelog files.
+
+Expected file changes: `package.json`, `CHANGELOG.md`, `.release-please-manifest.json` (and any release-only edits from `main`).
+
+### 4. Hotfixes on `main`
+
+If something lands on `main` outside the normal flow, open a manual `main` → `develop` sync PR and merge with a **merge commit**.
+
+## Workflow automation
+
+| Workflow | Trigger | Notes |
+|----------|---------|-------|
+| [release-please.yml](workflows/release-please.yml) | Push to `main` | Release PR, npm publish, opens sync PR |
+| [release-pr-build.yml](workflows/release-pr-build.yml) | Release Please PRs to `main` | Builds `dist/`, publishes `@next`, commits to PR branch |
+| [tests.yml](workflows/tests.yml) | Push | Unit tests |
+| [documentation.yml](workflows/documentation.yml) | Push / PR | Docs build and deploy |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,3 +56,70 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  sync-to-develop:
+    needs: [release-please, publish-npm]
+    if: ${{ needs.release-please.outputs.release_created == 'true' && needs.publish-npm.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Merge main into sync branch
+        env:
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          BRANCH="sync/main-after-${TAG}"
+          git fetch origin main
+          git merge origin/main --no-ff -m "chore: sync main after release ${TAG}"
+          git checkout -B "${BRANCH}"
+          git push origin "${BRANCH}" --force-with-lease
+
+      - name: Open sync pull request
+        id: sync-pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          BRANCH="sync/main-after-${TAG}"
+          TITLE="chore: sync main after release ${TAG}"
+          BODY="Automated sync after Release Please published ${TAG}.
+
+          **Maintainer action required:** approve and merge with **Create a merge commit** (not squash).
+
+          See [git workflow](https://github.com/${{ github.repository }}/blob/develop/docs/contributing/git-workflow.md)."
+
+          PR_NUM=$(gh pr list --base develop --head "${BRANCH}" --state open --json number -q '.[0].number // empty')
+
+          if [ -z "$PR_NUM" ]; then
+            gh pr create --base develop --head "${BRANCH}" --title "${TITLE}" --body "${BODY}"
+            PR_NUM=$(gh pr list --base develop --head "${BRANCH}" --state open --json number -q '.[0].number')
+          fi
+
+          echo "number=${PR_NUM}" >> "$GITHUB_OUTPUT"
+          echo "Opened sync PR #${PR_NUM}"
+
+      - name: Request maintainer review
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUM: ${{ steps.sync-pr.outputs.number }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          gh pr comment "${PR_NUM}" --body "**Post-release sync** — a maintainer must approve and merge this PR with **Create a merge commit** so \`develop\` receives the version bump and changelog from ${TAG}."
+          echo "::notice title=Maintainer action required::Approve and merge sync PR #${PR_NUM} into develop with a merge commit."

--- a/.github/workflows/release-pr-build.yml
+++ b/.github/workflows/release-pr-build.yml
@@ -49,7 +49,9 @@ jobs:
 
       - name: Commit dist to release PR
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add dist
           git diff --staged --quiet && exit 0
           git commit -m "chore: build dist for release [skip ci]"
-          git push
+          git push origin HEAD:${{ github.head_ref }}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We have [starter kits](https://github.com/LBHackney-IT/hackney-design-system-exa
 
 ## Contributing
 
-We use a feature-branching strategy. Make your pull requests to the `develop` branch.
+We use a feature-branching strategy. Make your pull requests to the `develop` branch. See [docs/contributing/git-workflow.md](docs/contributing/git-workflow.md) for release and branch-sync policy.
 
 **[See the full contributor guidance](https://design-system.hackney.gov.uk/contributing/introduction)**
 

--- a/docs/contributing/coding-standards.md
+++ b/docs/contributing/coding-standards.md
@@ -2,7 +2,7 @@
 title: Coding standards
 ---
 
-We use a feature-branching strategy. When making a pull request, make it to the [develop](https://github.com/LBHackney-IT/lbh-frontend/tree/develop) branch.
+We use a feature-branching strategy. When making a pull request, make it to the [develop](https://github.com/LBHackney-IT/lbh-frontend/tree/develop) branch. See [Git workflow](git-workflow) for how `develop` and `main` stay in sync at release time.
 
 ## Commit messages
 
@@ -28,7 +28,7 @@ The text inside the brackets indicates the scope of your changes. Normally this 
 
 After the colon, you can write your commit message as normal.
 
-You can read more about this format in the [semantic-release docs](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format).
+You can read more about this format in the [Angular commit message docs](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format). Release Please uses these messages on `main` to determine version bumps.
 
 ## Testing
 

--- a/docs/contributing/git-workflow.md
+++ b/docs/contributing/git-workflow.md
@@ -1,0 +1,68 @@
+---
+title: Git workflow
+---
+
+This repository uses two long-lived branches and [Release Please](https://github.com/googleapis/release-please) for npm releases.
+
+| Branch | Role |
+|--------|------|
+| `develop` | Default branch. All feature work lands here. |
+| `main` | Release branch. Receives promoted work and Release Please version bumps. |
+
+Keeping these branches aligned is critical. If they diverge, sync pull requests will conflict even when the code is nearly identical.
+
+## Day-to-day development
+
+1. Branch off `develop`.
+2. Open a pull request into `develop`.
+3. **Squash merge** the PR.
+4. Use [conventional commit titles](coding-standards) on the squash merge (for example `feat:`, `fix:`, `chore:`).
+
+Do not open feature pull requests directly into `main`.
+
+## Promoting work to main (without releasing yet)
+
+When a batch of work on `develop` is ready to be considered for release:
+
+1. Open a pull request: **`develop` → `main`**.
+2. **Merge with a merge commit** (not squash).
+3. Use a conventional commit title that reflects the change (for example `feat: upgrade toolchain for Node 24`).
+
+This push triggers Release Please on `main`. Release Please will open or update a **Release Please pull request** (`release-please--branches/...`). That PR accumulates the version bump and `CHANGELOG.md` update.
+
+You do **not** need to sync `main` back to `develop` at this stage. `develop` already contains the promoted code.
+
+## Releasing to npm
+
+1. Review and merge the **Release Please pull request** on `main` (merge commit is fine).
+2. The [Release please workflow](https://github.com/LBHackney-IT/lbh-frontend/actions/workflows/release-please.yml) publishes to npm `latest`.
+3. The same workflow opens a **`main` → `develop`** sync pull request (see below).
+4. A **maintainer approves and merges** that sync PR with a **merge commit**. Branch protection requires this — the automation cannot merge on its own.
+
+The sync step brings `package.json`, `CHANGELOG.md`, and `.release-please-manifest.json` back to `develop` so the branches stay aligned for the next cycle.
+
+## Syncing main to develop
+
+| When | Action |
+|------|--------|
+| After merging a **Release Please** PR on `main` | A maintainer approves and merges the automated sync PR (`main` → `develop`) with a **merge commit** |
+| After a **direct change to `main`** (hotfix, manual edit) | Open a manual `main` → `develop` PR and merge with a **merge commit** |
+| After promoting `develop` → `main` (before release) | No sync needed |
+
+Never squash-merge `main` into `develop`. Squash merges between long-lived branches break shared git history and cause repeated conflicts.
+
+## Merge method cheat sheet
+
+| Pull request | Merge method |
+|--------------|--------------|
+| Feature branch → `develop` | **Squash** |
+| `develop` → `main` (promotion) | **Merge commit** |
+| Release Please PR → `main` | **Merge commit** |
+| `main` → `develop` (sync) | **Merge commit** |
+
+## What not to do
+
+- Do not squash-merge the same work onto both `main` and `develop` as separate commits.
+- Do not land work on `main` before it exists on `develop`.
+- Do not manually open large “sync” PRs without resolving branch alignment first.
+- Do not use `feat:` on sync PRs — use `chore: sync main after release`.

--- a/sidebars.config.js
+++ b/sidebars.config.js
@@ -66,6 +66,7 @@ module.exports = {
     "Data visualisation": ["data-visualisation/getting-started"],
     Contributing: [
       "contributing/introduction",
+      "contributing/git-workflow",
       "contributing/coding-standards",
     ],
   },


### PR DESCRIPTION
## Summary

Promotes `develop` to `main` after branch alignment (#233–#235) and workflow cleanup (#236).

Brings to `main`:

- Post-release `main` → `develop` sync job in `release-please.yml`
- Git identity fix for dist commits in `release-pr-build.yml`
- Contributor git workflow docs and maintainer merge policy
- README / coding-standards links to the new workflow

## Files changed

7 files (~200 lines) — workflows, docs, and sidebar only. No package or component changes.