### PR TITLE
build: add a prerelease gate

### DIFF
--- a/.github/merge-policy.md
+++ b/.github/merge-policy.md
@@ -70,11 +70,3 @@ If something lands on `main` outside the normal flow, open a manual `main` → `
 | [publish-prerelease.yml](workflows/publish-prerelease.yml) | Manual (`workflow_dispatch`) | Publishes `X.Y.Z-next.N` to `@next` after environment approval |
 | [tests.yml](workflows/tests.yml) | Push | Unit tests |
 | [documentation.yml](workflows/documentation.yml) | Push / PR | Docs build and deploy |
-
-### `npm-prerelease` environment (one-time setup)
-
-1. **Settings → Environments → New environment** → name: `npm-prerelease`
-2. Enable **Required reviewers** and add maintainers
-3. Optionally restrict deployment branches to `main` and `release-please--*` patterns
-
-Without this environment, the publish workflow cannot run.

--- a/.github/merge-policy.md
+++ b/.github/merge-policy.md
@@ -29,13 +29,24 @@ Never squash-merge between `main` and `develop`.
 - Use a conventional title (`feat:`, `fix:`, etc.) — this feeds Release Please
 - **No sync back to `develop` yet** — file content is already on `develop`
 
-### 2. Merge Release Please PR on `main`
+### 2. Test a release candidate on npm (optional)
+
+When the Release Please PR is ready to test:
+
+1. **Actions → Publish npm prerelease → Run workflow**
+2. Set **git_ref** to the Release Please branch name (e.g. `release-please--branches--main--components--lbh-frontend`)
+3. Approve the run when prompted (**`npm-prerelease`** environment — see below)
+4. Install with `npm install lbh-frontend@next` or the exact `X.Y.Z-next.N` version from the workflow summary
+
+Each run publishes a new semver prerelease (`3.7.0-next.1`, `3.7.0-next.2`, …) so npm never rejects duplicate versions.
+
+### 3. Merge Release Please PR on `main`
 
 - PR branch name starts with `release-please--`
 - Merge with **merge commit**
 - [Release please workflow](workflows/release-please.yml) publishes to npm `latest`
 
-### 3. Merge the automated sync PR on `develop`
+### 4. Merge the automated sync PR on `develop`
 
 After a successful release, the workflow opens:
 
@@ -46,7 +57,7 @@ A maintainer must **approve and merge with a merge commit**. Branch protection p
 
 Expected file changes: `package.json`, `CHANGELOG.md`, `.release-please-manifest.json` (and any release-only edits from `main`).
 
-### 4. Hotfixes on `main`
+### 5. Hotfixes on `main`
 
 If something lands on `main` outside the normal flow, open a manual `main` → `develop` sync PR and merge with a **merge commit**.
 
@@ -55,6 +66,15 @@ If something lands on `main` outside the normal flow, open a manual `main` → `
 | Workflow | Trigger | Notes |
 |----------|---------|-------|
 | [release-please.yml](workflows/release-please.yml) | Push to `main` | Release PR, npm publish, opens sync PR |
-| [release-pr-build.yml](workflows/release-pr-build.yml) | Release Please PRs to `main` | Builds `dist/`, publishes `@next`, commits to PR branch |
+| [release-pr-build.yml](workflows/release-pr-build.yml) | Release Please PRs to `main` | Builds `dist/`, commits to PR branch |
+| [publish-prerelease.yml](workflows/publish-prerelease.yml) | Manual (`workflow_dispatch`) | Publishes `X.Y.Z-next.N` to `@next` after environment approval |
 | [tests.yml](workflows/tests.yml) | Push | Unit tests |
 | [documentation.yml](workflows/documentation.yml) | Push / PR | Docs build and deploy |
+
+### `npm-prerelease` environment (one-time setup)
+
+1. **Settings → Environments → New environment** → name: `npm-prerelease`
+2. Enable **Required reviewers** and add maintainers
+3. Optionally restrict deployment branches to `main` and `release-please--*` patterns
+
+Without this environment, the publish workflow cannot run.

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -1,0 +1,80 @@
+# Maintainer-triggered prerelease publish with approval gate.
+name: Publish npm prerelease
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: Branch or ref to publish (e.g. release-please--branches--main--components--lbh-frontend)
+        required: true
+        default: main
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish-prerelease:
+    runs-on: ubuntu-latest
+    environment: npm-prerelease
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.git_ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install modules
+        run: npm ci
+
+      - name: Build dist assets
+        run: npm run clean:dist && npm run build:dist
+
+      - name: Resolve unique prerelease version
+        id: version
+        run: |
+          BASE=$(node -p "require('./package.json').version")
+          PREFIX="${BASE}-next."
+          MAX_N=0
+
+          if VERSIONS=$(npm view lbh-frontend versions --json 2>/dev/null); then
+            while IFS= read -r v; do
+              if [[ "$v" == "${PREFIX}"* ]]; then
+                n="${v#${PREFIX}}"
+                if [[ "$n" =~ ^[0-9]+$ ]] && [ "$n" -gt "$MAX_N" ]; then
+                  MAX_N="$n"
+                fi
+              fi
+            done < <(echo "$VERSIONS" | jq -r '.[]')
+          fi
+
+          NEXT_N=$((MAX_N + 1))
+          PRERELEASE="${BASE}-next.${NEXT_N}"
+          echo "base=${BASE}" >> "$GITHUB_OUTPUT"
+          echo "prerelease=${PRERELEASE}" >> "$GITHUB_OUTPUT"
+          echo "Publishing ${PRERELEASE}"
+
+      - name: Set prerelease version for publish
+        run: npm version "${{ steps.version.outputs.prerelease }}" --no-git-tag-version --allow-same-version
+
+      - name: Publish to npm
+        run: npm publish --tag next --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "### Prerelease published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Version:** \`${{ steps.version.outputs.prerelease }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Dist-tag:** \`next\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Ref:** \`${{ inputs.git_ref }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`npm install lbh-frontend@${{ steps.version.outputs.prerelease }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Or: \`npm install lbh-frontend@next\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-pr-build.yml
+++ b/.github/workflows/release-pr-build.yml
@@ -34,18 +34,12 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: npm
-          registry-url: https://registry.npmjs.org
 
       - name: Install modules
         run: npm ci
 
       - name: Build dist assets
         run: npm run clean:dist && npm run build:dist
-
-      - name: Publish to npm for testing
-        run: npm publish --tag next --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Commit dist to release PR
         run: |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ We use a feature-branching strategy. Make your pull requests to the `develop` br
 ### npm releases
 
 - Pushes run unit tests and a production dependency audit (see `tests.yml`).
-- Release Please PRs build `dist/`, publish to the `next` dist-tag for testing (`npm install lbh-frontend@next`), and commit `dist/` to the PR (`release-pr-build.yml`).
+- Release Please PRs build `dist/` and commit it to the PR (`release-pr-build.yml`).
+- Maintainers can publish a prerelease to npm `@next` when ready (`publish-prerelease.yml` — requires approval on the `npm-prerelease` environment).
 - Merging a release publishes to npm `latest` (`release-please.yml`).
 
 ### Sass reference (`static/sassdoc`)

--- a/docs/contributing/git-workflow.md
+++ b/docs/contributing/git-workflow.md
@@ -39,6 +39,17 @@ You do **not** need to sync `main` back to `develop` at this stage. `develop` al
 3. The same workflow opens a **`main` → `develop`** sync pull request (see below).
 4. A **maintainer approves and merges** that sync PR with a **merge commit**. Branch protection requires this — the automation cannot merge on its own.
 
+### Testing before release (maintainers)
+
+Release Please PRs build `dist/` automatically but do **not** publish to npm. To test a candidate on npm:
+
+1. **Actions → Publish npm prerelease → Run workflow**
+2. Set **git_ref** to the Release Please branch name
+3. Approve the run on the **`npm-prerelease`** environment
+4. Install with `npm install lbh-frontend@next`
+
+Each approved run publishes a unique version such as `3.7.0-next.1`.
+
 The sync step brings `package.json`, `CHANGELOG.md`, and `.release-please-manifest.json` back to `develop` so the branches stay aligned for the next cycle.
 
 ## Syncing main to develop


### PR DESCRIPTION
What
--

* Removes automatic publish of test NPM package,
* Adds a manual step to publish a release package with `next.x` tag 