### PR TITLE
fix: dialog BEM selectors with radix modifier

### DIFF
--- a/lbh/components/lbh-dialog/_dialog.scss
+++ b/lbh/components/lbh-dialog/_dialog.scss
@@ -24,11 +24,13 @@
     background: lbh-colour("lbh-white");
     border: 4px solid lbh-colour("lbh-text");
 
-    &__title {
+    // Use full element class names — &__ would compile to .lbh-dialog--radix__*
+    // when the parent selector includes a BEM modifier on the same element.
+    .lbh-dialog__title {
       margin-top: 0;
     }
 
-    &__close {
+    .lbh-dialog__close {
       position: absolute;
       right: 7px;
       top: 7px;
@@ -52,7 +54,7 @@
       }
     }
 
-    &__actions {
+    .lbh-dialog__actions {
       display: flex;
       flex-direction: column;
       align-items: center;


### PR DESCRIPTION
## Summary

Fixes dialog styles not applying when using the Radix variant (`.lbh-dialog--radix`).

Nested `&__title`, `&__close`, and `&__actions` under `.lbh-dialog.lbh-dialog--radix` compiled to `.lbh-dialog--radix__*` instead of `.lbh-dialog__*`, so close button positioning, title margin, and actions layout never matched the DOM.

Uses explicit `.lbh-dialog__*` selectors scoped under the modifier block.

## Test plan

- [x] `npm test` passes
- [ ] Visual check: dialog close icon (top-right), bordered panel, overlay, action button layout
- [ ] Consumer apps can remove `_overrides.scss` dialog workarounds after release