### PR TITLE
feat: export Dialog with optional action footer

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,13 @@
 module.exports = (api) => {
-  if (api.env("test")) return {};
+  if (api.env("test")) {
+    return {
+      presets: [
+        ["@babel/preset-env", { targets: { node: "current" } }],
+        "@babel/preset-react",
+        "@babel/preset-typescript",
+      ],
+    };
+  }
 
   return {
     presets: [require.resolve("@docusaurus/core/lib/babel/preset")],

--- a/docs/components/dialog.md
+++ b/docs/components/dialog.md
@@ -21,45 +21,66 @@ Dialogs should only allow a user to take a single action. If many actions are po
 
 Our dialog component is only compatible with React. It uses [Radix UI Dialog](https://www.radix-ui.com/primitives/docs/components/dialog) for accessible modal behaviour.
 
+Import from the main package entry:
+
 ```jsx
 import React, { useState } from "react"
-import Dialog from "lbh-frontend/lbh/components/lbh-dialog"
-
-const DialogExample = () => {
-  const [open, setOpen] = useState(false)
-
-  return (
-    <>
-      <button
-        onClick={() => setOpen(!open)}
-        className="govuk-button lbh-button"
-      >
-        Preview dialog
-      </button>
-
-      <Dialog
-        title="Are you sure?"
-        isOpen={open}
-        onDismiss={() => setOpen(false)}
-      >
-        <p className="lbh-body">The record will be permanently deleted.</p>
-
-        <div className="lbh-dialog__actions">
-          <a href="#" className="govuk-button lbh-button">
-            Yes, delete
-          </a>
-
-          <button
-            onClick={() => setOpen(false)}
-            className="lbh-link lbh-link--no-visited-state"
-          >
-            No, cancel
-          </button>
-        </div>
-      </Dialog>
-    </>
-  )
-}
-
-export default DialogExample
+import { Dialog } from "lbh-frontend"
 ```
+
+### Informational (dismiss only)
+
+```jsx
+const [open, setOpen] = useState(false)
+
+<Dialog title="More information" isOpen={open} onDismiss={() => setOpen(false)}>
+  <p className="lbh-body">Use the close button to dismiss this dialog.</p>
+</Dialog>
+```
+
+### Confirm and cancel
+
+Optional actions render in `.lbh-dialog__actions` using existing design system button and link styles.
+
+```jsx
+<Dialog
+  title="Are you sure?"
+  isOpen={open}
+  onDismiss={() => setOpen(false)}
+  onConfirm={() => setOpen(false)}
+  confirmText="Yes, delete"
+  onCancel={() => setOpen(false)}
+>
+  <p className="lbh-body">The record will be permanently deleted.</p>
+</Dialog>
+```
+
+### Cancel link only
+
+```jsx
+<Dialog
+  title="Contact details"
+  isOpen={open}
+  onDismiss={() => setOpen(false)}
+  onCancel={() => setOpen(false)}
+  cancelText="Close"
+>
+  <p className="lbh-body">123 Example Street, London</p>
+</Dialog>
+```
+
+### Props
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `isOpen` | `boolean` | Yes | — | Controls whether the dialog is visible |
+| `onDismiss` | `() => void` | Yes | — | Called when the user closes via the X button or overlay |
+| `title` | `string` | Yes | — | Dialog heading |
+| `children` | `ReactNode` | Yes | — | Main dialog content |
+| `onConfirm` | `() => void` | No | — | Primary action handler |
+| `confirmText` | `string` | No | `"Yes"` | Primary action label |
+| `confirmButtonTestId` | `string` | No | — | `data-testid` for the confirm button |
+| `onCancel` | `() => void` | No | — | Secondary action handler |
+| `cancelText` | `string` | No | `"No, cancel"` | Secondary action label |
+
+If both `onConfirm` and `onCancel` are omitted, no action footer is rendered.

--- a/lbh/all.js
+++ b/lbh/all.js
@@ -11,6 +11,7 @@ import Map from "./components/lbh-contact-block/contact-block";
 import Radios from "./components/lbh-radios/radios";
 import Tabs from "./components/lbh-tabs/tabs";
 import Collapsible from "./components/lbh-collapsible/collapsible";
+import Dialog from "./components/lbh-dialog/index";
 
 function nodeListForEach(nodes, callback) {
   if (window.NodeList.prototype.forEach) {
@@ -63,6 +64,7 @@ export {
   Checkboxes,
   CookieBanner,
   Details,
+  Dialog,
   ErrorSummary,
   Map,
   Radios,

--- a/lbh/components/lbh-dialog/dialog.test.tsx
+++ b/lbh/components/lbh-dialog/dialog.test.tsx
@@ -1,0 +1,121 @@
+import React from "react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
+import Dialog from "./index"
+
+describe("Dialog", () => {
+  it("renders title, children, and close button", () => {
+    render(
+      <Dialog isOpen title="Delete record" onDismiss={() => {}}>
+        <p>Are you sure?</p>
+      </Dialog>
+    )
+
+    expect(screen.getByRole("heading", { name: "Delete record" })).toBeTruthy()
+    expect(screen.getByText("Are you sure?")).toBeTruthy()
+    expect(screen.getByRole("button", { name: "Close" })).toBeTruthy()
+  })
+
+  it("does not render actions when no action props are provided", () => {
+    render(
+      <Dialog isOpen title="Information" onDismiss={() => {}}>
+        <p>Details only</p>
+      </Dialog>
+    )
+
+    expect(document.body.querySelector(".lbh-dialog__actions")).toBeNull()
+  })
+
+  it("renders confirm and cancel actions when provided", () => {
+    render(
+      <Dialog
+        isOpen
+        title="Delete record"
+        onDismiss={() => {}}
+        onConfirm={() => {}}
+        confirmText="Yes, delete"
+        onCancel={() => {}}
+        cancelText="No, cancel"
+      >
+        <p>Content</p>
+      </Dialog>
+    )
+
+    expect(screen.getByRole("button", { name: "Yes, delete" })).toBeTruthy()
+    expect(screen.getByRole("button", { name: "No, cancel" })).toBeTruthy()
+  })
+
+  it("renders only confirm when onCancel is omitted", () => {
+    render(
+      <Dialog
+        isOpen
+        title="Sign out"
+        onDismiss={() => {}}
+        onConfirm={() => {}}
+        confirmText="Stay logged in"
+      >
+        <p>You will be signed out.</p>
+      </Dialog>
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Stay logged in" })
+    ).toBeTruthy()
+    expect(screen.queryByRole("button", { name: "No, cancel" })).toBeNull()
+  })
+
+  it("renders only cancel when onConfirm is omitted", () => {
+    render(
+      <Dialog
+        isOpen
+        title="Address"
+        onDismiss={() => {}}
+        onCancel={() => {}}
+        cancelText="Close"
+      >
+        <p>Address details</p>
+      </Dialog>
+    )
+
+    const actions = document.body.querySelector(".lbh-dialog__actions")
+    expect(actions).toBeTruthy()
+    expect(within(actions as HTMLElement).getByRole("button", { name: "Close" })).toBeTruthy()
+    expect(screen.queryByRole("button", { name: "Yes" })).toBeNull()
+  })
+
+  it("calls onDismiss when the close button is clicked", () => {
+    const onDismiss = jest.fn()
+
+    render(
+      <Dialog isOpen title="Close me" onDismiss={onDismiss}>
+        <p>Content</p>
+      </Dialog>
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it("calls onConfirm and onCancel when action buttons are clicked", () => {
+    const onConfirm = jest.fn()
+    const onCancel = jest.fn()
+
+    render(
+      <Dialog
+        isOpen
+        title="Confirm"
+        onDismiss={() => {}}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        confirmButtonTestId="confirm-action"
+      >
+        <p>Content</p>
+      </Dialog>
+    )
+
+    fireEvent.click(screen.getByTestId("confirm-action"))
+    fireEvent.click(screen.getByRole("button", { name: "No, cancel" }))
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/lbh/components/lbh-dialog/index.tsx
+++ b/lbh/components/lbh-dialog/index.tsx
@@ -1,11 +1,20 @@
 import React from "react"
 import * as RadixDialog from "@radix-ui/react-dialog"
 
-interface Props {
+export interface DialogProps
+  extends Omit<
+    React.ComponentPropsWithoutRef<typeof RadixDialog.Content>,
+    "title"
+  > {
   isOpen: boolean
   onDismiss: () => void
-  children: React.ReactNode
   title: string
+  children: React.ReactNode
+  onConfirm?: () => void
+  confirmText?: string
+  confirmButtonTestId?: string
+  onCancel?: () => void
+  cancelText?: string
 }
 
 const Dialog = ({
@@ -13,40 +22,76 @@ const Dialog = ({
   onDismiss,
   children,
   title,
+  onConfirm,
+  confirmText = "Yes",
+  confirmButtonTestId,
+  onCancel,
+  cancelText = "No, cancel",
   ...props
-}: Props): React.ReactElement => (
-  <RadixDialog.Root
-    open={isOpen}
-    onOpenChange={(open) => {
-      if (!open) onDismiss()
-    }}
-  >
-    <RadixDialog.Portal>
-      <RadixDialog.Overlay className="lbh-dialog__overlay" />
-      <RadixDialog.Content className="lbh-dialog lbh-dialog--radix" {...props}>
-        <RadixDialog.Title asChild>
-          <h2 className="lbh-heading-h2 lbh-dialog__title">{title}</h2>
-        </RadixDialog.Title>
-        {children}
-        <RadixDialog.Close asChild>
-          <button type="button" className="lbh-dialog__close">
-            <span className="govuk-visually-hidden">Close</span>
+}: DialogProps): React.ReactElement => {
+  const showActions = Boolean(onConfirm || onCancel)
 
-            <svg width="18" height="18" viewBox="0 0 13 13" fill="none">
-              <path
-                d="M-0.0501709 1.36379L1.36404 -0.050415L12.6778 11.2633L11.2635 12.6775L-0.0501709 1.36379Z"
-                fill="#0B0C0C"
-              />
-              <path
-                d="M11.2635 -0.050293L12.6778 1.36392L1.36404 12.6776L-0.0501709 11.2634L11.2635 -0.050293Z"
-                fill="#0B0C0C"
-              />
-            </svg>
-          </button>
-        </RadixDialog.Close>
-      </RadixDialog.Content>
-    </RadixDialog.Portal>
-  </RadixDialog.Root>
-)
+  return (
+    <RadixDialog.Root
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onDismiss()
+      }}
+    >
+      <RadixDialog.Portal>
+        <RadixDialog.Overlay className="lbh-dialog__overlay" />
+        <RadixDialog.Content
+          className="lbh-dialog lbh-dialog--radix"
+          aria-describedby={undefined}
+          {...props}
+        >
+          <RadixDialog.Title asChild>
+            <h2 className="lbh-heading-h2 lbh-dialog__title">{title}</h2>
+          </RadixDialog.Title>
+          {children}
+          <RadixDialog.Close asChild>
+            <button type="button" className="lbh-dialog__close">
+              <span className="govuk-visually-hidden">Close</span>
+
+              <svg width="18" height="18" viewBox="0 0 13 13" fill="none">
+                <path
+                  d="M-0.0501709 1.36379L1.36404 -0.050415L12.6778 11.2633L11.2635 12.6775L-0.0501709 1.36379Z"
+                  fill="#0B0C0C"
+                />
+                <path
+                  d="M11.2635 -0.050293L12.6778 1.36392L1.36404 12.6776L-0.0501709 11.2634L11.2635 -0.050293Z"
+                  fill="#0B0C0C"
+                />
+              </svg>
+            </button>
+          </RadixDialog.Close>
+          {showActions && (
+            <div className="lbh-dialog__actions">
+              {onConfirm && (
+                <button
+                  type="button"
+                  className="govuk-button lbh-button"
+                  onClick={onConfirm}
+                  data-testid={confirmButtonTestId}
+                >
+                  {confirmText}
+                </button>
+              )}
+              {onCancel && (
+                <button
+                  type="button"
+                  className="lbh-link lbh-link--no-visited-state"
+                  onClick={onCancel}
+                >
+                  {cancelText}
+                </button>
+              )}
+            </div>
+          )}
+        </RadixDialog.Content>
+      </RadixDialog.Portal>
+    </RadixDialog.Root>
+  )
+}
 
 export default Dialog

--- a/lbh/index.d.ts
+++ b/lbh/index.d.ts
@@ -6,6 +6,7 @@ import { default as Checkboxes } from "./components/lbh-checkboxes/checkboxes";
 import { default as Collapsible } from "./components/lbh-collapsible/collapsible";
 import { default as CookieBanner } from "./components/lbh-cookie-banner/cookie-banner";
 import { default as Details } from "./components/lbh-details/details";
+import { default as Dialog } from "./components/lbh-dialog/index";
 import { default as ErrorSummary } from "./components/lbh-error-summary/error-summary";
 import { default as Map } from "./components/lbh-contact-block/contact-block";
 import { default as Radios } from "./components/lbh-radios/radios";
@@ -26,11 +27,14 @@ export {
   Collapsible,
   CookieBanner,
   Details,
+  Dialog,
   ErrorSummary,
   Map,
   Radios,
   Tabs,
 };
+
+export type { DialogProps } from "./components/lbh-dialog/index";
 
 declare global {
   interface Window {

--- a/src/DialogExample.jsx
+++ b/src/DialogExample.jsx
@@ -1,37 +1,66 @@
 import React, { useState } from "react"
-import Dialog from "../lbh/components/lbh-dialog"
+import { Dialog } from "../lbh/all.js"
 
 const DialogExample = () => {
-  const [open, setOpen] = useState(false)
+  const [informationalOpen, setInformationalOpen] = useState(false)
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [cancelOnlyOpen, setCancelOnlyOpen] = useState(false)
 
   return (
     <>
-      <button
-        onClick={() => setOpen(!open)}
-        className="govuk-button lbh-button"
+      <div className="govuk-button-group">
+        <button
+          type="button"
+          onClick={() => setInformationalOpen(true)}
+          className="govuk-button lbh-button"
+        >
+          Informational dialog
+        </button>
+
+        <button
+          type="button"
+          onClick={() => setConfirmOpen(true)}
+          className="govuk-button lbh-button"
+        >
+          Confirm and cancel
+        </button>
+
+        <button
+          type="button"
+          onClick={() => setCancelOnlyOpen(true)}
+          className="govuk-button lbh-button"
+        >
+          Cancel link only
+        </button>
+      </div>
+
+      <Dialog
+        title="More information"
+        isOpen={informationalOpen}
+        onDismiss={() => setInformationalOpen(false)}
       >
-        Preview dialog
-      </button>
+        <p className="lbh-body">Use the close button to dismiss this dialog.</p>
+      </Dialog>
 
       <Dialog
         title="Are you sure?"
-        isOpen={open}
-        onDismiss={() => setOpen(false)}
+        isOpen={confirmOpen}
+        onDismiss={() => setConfirmOpen(false)}
+        onConfirm={() => setConfirmOpen(false)}
+        confirmText="Yes, delete"
+        onCancel={() => setConfirmOpen(false)}
       >
         <p className="lbh-body">The record will be permanently deleted.</p>
+      </Dialog>
 
-        <div className="lbh-dialog__actions">
-          <a href="#" className="govuk-button lbh-button">
-            Yes, delete
-          </a>
-
-          <button
-            onClick={() => setOpen(false)}
-            className="lbh-link lbh-link--no-visited-state"
-          >
-            No, cancel
-          </button>
-        </div>
+      <Dialog
+        title="Contact details"
+        isOpen={cancelOnlyOpen}
+        onDismiss={() => setCancelOnlyOpen(false)}
+        onCancel={() => setCancelOnlyOpen(false)}
+        cancelText="Close"
+      >
+        <p className="lbh-body">123 Example Street, London</p>
       </Dialog>
     </>
   )


### PR DESCRIPTION
## Summary
- Export `Dialog` and `DialogProps` from the main `lbh-frontend` package entry so consuming apps no longer need a local Radix wrapper or a direct `@radix-ui/react-dialog` dependency.
- Add optional `onConfirm` / `onCancel` action props that render inside the existing `.lbh-dialog__actions` SCSS pattern (primary button + cancel link).
- Add component tests, update docs with informational / confirm+cancel / cancel-only examples, and configure Jest to transform `.tsx` in the test environment.

## Test plan
- [x] `npm test` passes (including new `lbh/components/lbh-dialog/dialog.test.tsx`)
- [x] `npm run lint` passes
- [ ] Docs site preview shows three dialog examples on the Dialog page
- [ ] Verify `import { Dialog } from 'lbh-frontend'` resolves with TypeScript types
- [ ] Housing Register can replace its local `components/dialog.tsx` after upgrading