### PR TITLE
fix: import Dialog directly in docs example for SSG

### DIFF
--- a/src/DialogExample.jsx
+++ b/src/DialogExample.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { Dialog } from "../lbh/all.js"
+import Dialog from "../lbh/components/lbh-dialog"
 
 const DialogExample = () => {
   const [informationalOpen, setInformationalOpen] = useState(false)


### PR DESCRIPTION
## Summary
- Fixes Docusaurus static site generation for `/components/dialog` after #257 merged.
- `DialogExample` imported `lbh/all.js`, which pulls in client-only code referencing `document` during SSG.
- Import the Dialog component directly, matching the existing `TipExamples` pattern.

## Test plan
- [x] `npm run build:docs` passes locally
- [ ] Publish documentation check passes on this PR