### PR TITLE
feat: add lbh-frontend/dialog package subpath export

### DIFF
--- a/docs/components/dialog.md
+++ b/docs/components/dialog.md
@@ -21,12 +21,16 @@ Dialogs should only allow a user to take a single action. If many actions are po
 
 Our dialog component is only compatible with React. It uses [Radix UI Dialog](https://www.radix-ui.com/primitives/docs/components/dialog) for accessible modal behaviour.
 
-Import from the main package entry:
+Import from the main package entry or the Dialog subpath:
 
 ```jsx
 import React, { useState } from "react"
 import { Dialog } from "lbh-frontend"
+// or
+import Dialog from "lbh-frontend/dialog"
 ```
+
+Use the subpath when you only need Dialog and want to avoid importing the full package bundle.
 
 ### Informational (dismiss only)
 

--- a/docs/developing/installing-from-npm.md
+++ b/docs/developing/installing-from-npm.md
@@ -128,6 +128,12 @@ import { initAll } from "lbh-frontend"
 initAll()
 ```
 
+React-only components can be imported from package subpaths without pulling in the full bundle. For example:
+
+```js
+import Dialog from "lbh-frontend/dialog"
+```
+
 `initAll()` must be called _after_ the HTML has been rendered to the page. If you're using React, there are some [extra things you need to do](https://design-system.hackney.gov.uk/developing/react).
 
 ### Initialise individual components (optional)

--- a/lbh/dialog.d.ts
+++ b/lbh/dialog.d.ts
@@ -1,0 +1,1 @@
+export { default, default as Dialog, DialogProps } from "./components/lbh-dialog/index";

--- a/lbh/dialog.js
+++ b/lbh/dialog.js
@@ -1,0 +1,2 @@
+export { default } from "./components/lbh-dialog/index";
+export { default as Dialog } from "./components/lbh-dialog/index";

--- a/package.json
+++ b/package.json
@@ -6,6 +6,17 @@
   "homepage": "https://design-system.hackney.gov.uk",
   "main": "lbh/all.js",
   "types": "lbh/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lbh/index.d.ts",
+      "default": "./lbh/all.js"
+    },
+    "./dialog": {
+      "types": "./lbh/dialog.d.ts",
+      "default": "./lbh/dialog.js"
+    },
+    "./lbh/*": "./lbh/*"
+  },
   "files": [
     "lbh",
     "CHANGELOG.md"

--- a/scripts/verify-pack.js
+++ b/scripts/verify-pack.js
@@ -4,6 +4,10 @@ const { join } = require("path");
 
 const root = join(__dirname, "..");
 const requiredPrefixes = ["package/lbh/", "package/CHANGELOG.md"];
+const requiredPaths = [
+  "package/lbh/dialog.js",
+  "package/lbh/dialog.d.ts",
+];
 const forbiddenPrefixes = ["package/dist/"];
 
 const existingTarballs = new Set(
@@ -33,6 +37,13 @@ try {
       console.error(
         `verify:pack: missing ${prefix.replace("package/", "")} in pack`
       );
+      process.exit(1);
+    }
+  }
+
+  for (const path of requiredPaths) {
+    if (!listing.includes(path)) {
+      console.error(`verify:pack: missing ${path.replace("package/", "")} in pack`);
       process.exit(1);
     }
   }


### PR DESCRIPTION
## Summary
- Add `lbh-frontend/dialog` as a package exports subpath with dedicated `lbh/dialog.js` and `lbh/dialog.d.ts` entry files.
- Consumers can use `import Dialog from "lbh-frontend/dialog"` (or named `Dialog` / `DialogProps`) without deep imports or local barrels.
- Add `exports` to `package.json` with a `./lbh/*` wildcard so existing Sass and deep JS imports keep working.
- Document the subpath on the Dialog page and in the npm install guide; extend `verify:pack` to assert the new entry files ship in the tarball.

## Test plan
- [x] `npm run verify:pack` passes
- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] `npm run build:docs` passes
- [ ] Consumer can `import Dialog from "lbh-frontend/dialog"` with TypeScript types after release